### PR TITLE
use centos as the base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,9 @@ dist: xenial
 language: python
 python: 3.7
 services: docker
-env:
-- OS_VERSION=bionic GIT_URL=https://github.com/ceph/ceph            GIT_REF=octopus          IMG="popperized/ceph-builder:octopus-bionic"
-- OS_VERSION=bionic GIT_URL=https://github.com/ceph/ceph            GIT_REF=nautilus         IMG="popperized/ceph-builder:nautilus-bionic"
-- OS_VERSION=bionic GIT_URL=https://github.com/ceph/ceph            GIT_REF=mimic            IMG="popperized/ceph-builder:mimic-bionic"
-- OS_VERSION=bionic GIT_URL=https://github.com/uccross/skyhook-ceph GIT_REF=skyhook-luminous IMG="popperized/ceph-builder:skyhook-bionic"
 install:
 - git clone https://github.com/systemslab/popper /tmp/popper
 - export PYTHONUNBUFFERED=1
 - pip install /tmp/popper/cli
 script: >-
-  popper run -f ci/wf.yml \
-    --substitution "_OS_VERSION=$OS_VERSION" \
-    --substitution "_GIT_URL=$GIT_URL" \
-    --substitution "_GIT_REF=$GIT_REF" \
-    --substitution "_IMG=$IMG"
+  popper run -f ci/wf.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,17 @@
-ARG OS_VERSION=bionic
-FROM ubuntu:${OS_VERSION}
+FROM centos:7.8.2003
 
-ARG DEBIAN_FRONTEND=noninteractive
-ARG GIT_URL="https://github.com/ceph/ceph"
-ARG GIT_REF="master"
+ARG GIT_URL="https://github.com/uccross/skyhookdm-ceph"
+ARG GIT_REF="skyhook-luminous"
 ARG EXTRA_PKGS=""
 
-RUN apt-get update && \
-    apt-get install -y git gnupg2 ccache && \
+ADD . /
+
+RUN ./install-preq.sh && \
     git clone --branch $GIT_REF --depth 1 $GIT_URL ceph && \
     cd ceph && \
     ./install-deps.sh && \
     sh -c 'if [ -n "$EXTRA_PKGS" ]; then apt-get install -y "$EXTRA_PKGS"; fi' && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* debian/
+    yum clean all
 
 COPY entrypoint.sh /
 

--- a/ci/wf.yml
+++ b/ci/wf.yml
@@ -1,18 +1,17 @@
 steps:
 - uses: docker://docker:19.03.3
-  args: ['build',
-    '--build-arg', 'OS_VERSION=$_OS_VERSION', 
-    '--build-arg', 'GIT_URL=$_GIT_URL',
-    '--build-arg', 'GIT_REF=$_GIT_REF',
-    '--tag', '$_IMG',
-    '.'
-  ]
+  args: ['build', 
+         '--build-arg', 'GIT_URL=https://github.com/uccross/skyhookdm-ceph',
+         '--build-arg', 'GIT_REF=skyhook-luminous',
+         '-t', 'jcnitdgp25/ceph-builder:skyhook-luminous-centos',
+         '.'
+        ]
 
 - uses: docker://docker:19.03.3
-  runs: /bin/sh
+  runs: ['/bin/sh']
   secrets: [DOCKER_USERNAME, DOCKER_PASSWORD]
   args:
   - -c
   - |
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    docker push $_IMG
+    docker push jcnitdgp25/ceph-builder:skyhook-luminous-centos

--- a/install-preq.sh
+++ b/install-preq.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+# yum update -y
+yum install -y centos-release-scl scl-utils epel-release
+yum install -y git wget gnupg2 ccache
+yum install -y python-pip
+yum install -y devtoolset-8 devtoolset-7
+# pip install --upgrade pip
+# pip install --upgrade virtualenv
+scl enable devtoolset-8 bash
+scl enable devtoolset-7 bash


### PR DESCRIPTION
Please ignore the changes in `.travis.yml` and `wf.yml`. Those are because of the substitutions [bug](https://github.com/getpopper/popper/issues/842) in popper.  